### PR TITLE
Build solventlist based on Chemical Inventory

### DIFF
--- a/capture/devconfig.py
+++ b/capture/devconfig.py
@@ -1,7 +1,7 @@
 import platform
 
 #######################################
-# version control todo: ian where does this get used? Not sure if we should have to manually do this
+# version control
 RoboVersion = 2.5
 
 SUPPORTED_LABS = ['LBL', 'HC', 'MIT_PVLab', 'ECL', 'dev']
@@ -11,10 +11,6 @@ SUPPORTED_LABS = ['LBL', 'HC', 'MIT_PVLab', 'ECL', 'dev']
 
 maxreagentchemicals = 4
 volspacing = 50  # reagent microliter (uL) spacing between points in the stateset
-
-# perovskite solvent list (simple specification of what is a liquid)
-# assumes only 1 liquid / reagent
-solventlist = ['GBL', 'DMSO', 'DMF', 'DCM', 'CBz']
 
 #######################################
 # Lab-specific variables

--- a/capture/models/chemical.py
+++ b/capture/models/chemical.py
@@ -8,7 +8,7 @@ class perovskitechemical:
     def __init__(self, rxndict, chemdf):
         pass
 
-def ChemicalData(chemsheetid, chemsheetworkbook):
+def build_chemdf(chemsheetid, chemsheetworkbook):
     """Get the chemical sheet from the chemical inventory
 
     :param chemsheetid:       todo this is a workbook (and unused)

--- a/capture/models/reagent.py
+++ b/capture/models/reagent.py
@@ -5,7 +5,7 @@ import gspread
 from capture.googleapi import googleio
 from oauth2client.service_account import ServiceAccountCredentials
 
-def ReagentData(reagsheetid, reagsheetworkbook):
+def build_reagentdf(reagsheetid, reagsheetworkbook):
     """Read the reagents workbook from Google Drive and return a pandas DataFrame
 
     :param reagsheetid:        TODO this is a workbook (and unused)

--- a/capture/specify.py
+++ b/capture/specify.py
@@ -43,6 +43,8 @@ def datapipeline(rxndict, vardict):
     reagentdf = reagent.build_reagentdf(config.lab_vars[globals.get_lab()]['reagentsheetid'],
                                         config.lab_vars[globals.get_lab()]['reagent_workbook_index'])
 
+    vardict['solventlist'] = chemdf.index[chemdf['Chemical Category'] == 'solvent'].values.tolist()
+
     # dictionary of user defined chemical limits
     climits = chemical.chemicallimits(rxndict)
 

--- a/capture/specify.py
+++ b/capture/specify.py
@@ -38,10 +38,10 @@ def datapipeline(rxndict, vardict):
 
     modlog = logging.getLogger('capture.specify.datapipeline')
     inputvalidation.prebuildvalidation(rxndict, vardict)
-    chemdf = chemical.ChemicalData(config.lab_vars[globals.get_lab()]['chemsheetid'],
+    chemdf = chemical.build_chemdf(config.lab_vars[globals.get_lab()]['chemsheetid'],
                                    config.lab_vars[globals.get_lab()]['chem_workbook_index'])
-    reagentdf = reagent.ReagentData(config.lab_vars[globals.get_lab()]['reagentsheetid'],
-                                    config.lab_vars[globals.get_lab()]['reagent_workbook_index'])
+    reagentdf = reagent.build_reagentdf(config.lab_vars[globals.get_lab()]['reagentsheetid'],
+                                        config.lab_vars[globals.get_lab()]['reagent_workbook_index'])
 
     # dictionary of user defined chemical limits
     climits = chemical.chemicallimits(rxndict)


### PR DESCRIPTION
This allows users to define solvents in the Chemical Inventory without having to also specify them in `devconfig`. This is part of our larger push to allow users to specify arbitrary chemical categories in the Chemical Inventory. 

This change removes the `solventlist` from `devconfig` and computes it on the fly inside of `capture.specify`, requiring only one line:

https://github.com/darkreactions/ESCALATE_Capture/blob/513a44559faaee95db9a25109a85ab8211cf5c56/capture/specify.py#L46

This attribute of the `vardict` is then used as usual. 

I tested this with the HC/LBL Chemical Inventory and the `solventlist` was identical to that specified in `devconfig`, save being in a different order.

@ipendlet we just need to add a Chemical Category to the MIT Chemical Inventory and we are good to go. 

----
Note: I considered building the `solventlist` in `runme` where most of the `vardict` is built out, but since the `solventlist` depends on the `chemdf` this is the best place to build it.  