### PR TITLE
extend conditional to windows and other OS's

### DIFF
--- a/capture/devconfig.py
+++ b/capture/devconfig.py
@@ -98,14 +98,19 @@ if system == "Linux":
         print('WolframKernel not successfully found, please correct devconfig')
         import sys
         sys.exit()
-        
+
 # Mac
 elif system == "Darwin":
     wolfram_kernel_path = None
 
-#Windows (or some weird unanticipated OS)
-else:
+# Windows
+# Needs to be tested on a window's machine, but the internet tells me that 'Windows' should be what system is equal to. 
+elif system == 'Windows':
     wolfram_kernel_path = None
+
+# Other
+else:
+    raise OSError("Your system is likely not supported if it's not Linux, MAC, or Windows")
 
 ######################################
 # Sampler Selection

--- a/capture/devconfig.py
+++ b/capture/devconfig.py
@@ -81,6 +81,7 @@ lab_vars = {
 #######################################
 # Wolfram Kernel Management
 
+wolfram_kernel_path = None # ensure the value can be imported on all computers.
 
 system = platform.system()
 if system == "Linux":
@@ -99,13 +100,10 @@ if system == "Linux":
         import sys
         sys.exit()
 
-# Mac
-elif system == "Darwin":
-    wolfram_kernel_path = None
-
-# Windows
-# Needs to be tested on a window's machine, but the internet tells me that 'Windows' should be what system is equal to. 
-elif system == 'Windows':
+# Mac or Windows
+# Needs to be tested on a window's machine, but the internet
+# tells me that 'Windows' should be what system is equal to.
+elif system == "Darwin" or system == 'Windows':
     wolfram_kernel_path = None
 
 # Other

--- a/capture/devconfig.py
+++ b/capture/devconfig.py
@@ -98,8 +98,13 @@ if system == "Linux":
         print('WolframKernel not successfully found, please correct devconfig')
         import sys
         sys.exit()
+        
 # Mac
 elif system == "Darwin":
+    wolfram_kernel_path = None
+
+#Windows (or some weird unanticipated OS)
+else:
     wolfram_kernel_path = None
 
 ######################################


### PR DESCRIPTION
Define `wolfram_kernel_path` for all OS's, not just Linux and Mac. 