### PR TITLE
Only request reagents be prepared if they are used

### DIFF
--- a/capture/models/reagent.py
+++ b/capture/models/reagent.py
@@ -5,6 +5,8 @@ import gspread
 from capture.googleapi import googleio
 from oauth2client.service_account import ServiceAccountCredentials
 
+from utils.data_handling import get_used_reagent_nums
+
 def build_reagentdf(reagsheetid, reagsheetworkbook):
     """Read the reagents workbook from Google Drive and return a pandas DataFrame
 
@@ -40,6 +42,8 @@ def buildreagents(rxndict, chemdf, reagentdf, solventlist):
     modlog = logging.getLogger('capture.models.reagent.buildreagents')
     reagentdict = {}
 
+
+    used_reagent_nums = get_used_reagent_nums(rxndict)
     for item in rxndict:
 
         # parse 'list-style' reagent specifications from Template
@@ -50,9 +54,12 @@ def buildreagents(rxndict, chemdf, reagentdf, solventlist):
             if idflag in rxndict:
                 print('too many %s' % reagentname)
             else:
+                entry_num = reagentname.split('t')[1]
                 reagentvariables = {}
                 reagentvariables['reagent'] = reagentname
-                entry_num = reagentname.split('t')[1]
+
+                if int(entry_num) not in used_reagent_nums:
+                    continue
 
                 for variable, value in rxndict.items():
                     if reagentname in variable and '(ul)' not in variable:
@@ -72,6 +79,8 @@ def buildreagents(rxndict, chemdf, reagentdf, solventlist):
             reagentvariables = {}
             reagentname = item.split('_')[0]
             entry_num = reagentname.split('t')[1]
+            if int(entry_num) not in used_reagent_nums:
+                continue
             reagentid = rxndict[item]
             reagentvariables['reagent'] = reagentname
             chemical_list = []

--- a/utils/data_handling.py
+++ b/utils/data_handling.py
@@ -117,3 +117,8 @@ def get_user_actions(rxndict, sheet):
     # add new userActions here.
 
     rxndict['user_actions'] = userActions
+
+
+def get_used_reagent_nums(rxndict):
+    expoverviews = [rxndict[k] for k in rxndict.keys() if re.match('^exp\d+$', k)]
+    return flatten(expoverviews)


### PR DESCRIPTION
closes #86. 

@ipendlet see if it works to your liking and we can clean up and merge.
## Summary

### Problem
Issue #86 assumes that the new region sampler is the culprit for the following problem: if a reagent is defined in the **Materials** section of `*_specification_interface.xlsx` but this reagent is **not** referenced in any of the experiment_\<i\> reagents lists, then this reagent will still be requested for preparation in the `preparation_interface`, despite this reagent not actually being used in any wells. 

Test results in our [issue86 gdrive folder](https://drive.google.com/drive/u/1/folders/1ZF3aj9WRNk8F216FIvZz8Tq4M-OAY6dm) show that this bug is actually a general property of the current ESCALATE implementation. It is caused by all reagents in the `rdict` being fed to the [function that generates the reagent specification interface](https://github.com/darkreactions/ESCALATE_Capture/blob/b0214f0bc9d09b0440bd5f40d61f55153ebb803f/capture/specify.py#L111). The `rdict` contains all reagents defined in the **Materials** section of the specification interface, regardless of whether or not they are used.

### Solution
My solution was simple: if a reagent doesn't show up [in the lists of experiment reagents](https://github.com/darkreactions/ESCALATE_Capture/blob/9ab52771cdb6535f0c81387d2d55eedd37600426/capture/models/reagent.py#L46), then [don't put it in the `rdict`](https://github.com/darkreactions/ESCALATE_Capture/blob/9ab52771cdb6535f0c81387d2d55eedd37600426/capture/models/reagent.py#L61).